### PR TITLE
Fix parsing for aliased bubble imports (#42)

### DIFF
--- a/apps/bubblelab-api/.eslintrc.json
+++ b/apps/bubblelab-api/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "extends": ["../../tools/eslint-config/node.js"],
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.json",
+    "tsconfigRootDir": "."
   },
   "ignorePatterns": ["dist", "node_modules", "jest.config.js"],
   "rules": {


### PR DESCRIPTION
## Summary
- Fix bubble parsing when bubbles are imported with aliases (e.g., `import { ResearchAgentTool as ResearchAgent }`).
- Add alias-resolution to both parsers (core and API) so aliased constructors map to registered bubble classes.
- Extend reconstruction to respect aliases and add tests covering single and multiple alias cases.
- Set `tsconfigRootDir` in API ESLint config to resolve lint parsing in the monorepo.

## Related Issues
- Fixes #42

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] My code follows the code style of this project
- [x] I have added appropriate tests for my changes
- [ ] I have run `pnpm check` and all tests pass (did not run full suite; `pnpm build:core` passes; ESLint shows pre-existing warnings/errors outside touched files)
- [x] I have tested my changes locally (`pnpm build:core`)
- [x] I have linked relevant issues
- [ ] I have added screenshots for UI changes (not applicable)

## Screenshots (if applicable)
N/A

## Additional Context
- Lint surfaced existing warnings/errors in other files; not addressed here.