### PR TITLE
fix(bubble-studio): show flow 404 fallback

### DIFF
--- a/apps/bubble-studio/src/components/FlowIDEView.tsx
+++ b/apps/bubble-studio/src/components/FlowIDEView.tsx
@@ -27,6 +27,8 @@ import { filterEmptyInputs } from '@/utils/inputUtils';
 import { useRenameFlow } from '@/hooks/useRenameFlow';
 import { useEffect } from 'react';
 import { shallow } from 'zustand/shallow';
+import { ApiHttpError } from '@/lib/api';
+import { FlowNotFoundView } from '@/components/FlowNotFoundView';
 
 export interface FlowIDEViewProps {
   flowId: number;
@@ -60,12 +62,17 @@ export function FlowIDEView({ flowId }: FlowIDEViewProps) {
   );
 
   // ============= React Query Hooks =============
-  const { data: currentFlow } = useBubbleFlow(flowId);
+  const { data: currentFlow, error, refetch } = useBubbleFlow(flowId);
   const { runFlow, isRunning, canExecute } = useRunExecution(flowId);
   const validateCodeMutation = useValidateCode({ flowId });
   const { data: executionHistory } = useExecutionHistory(flowId, {
     limit: 10,
   });
+
+  const isFlowNotFound =
+    error instanceof ApiHttpError
+      ? error.status === 404
+      : error instanceof Error && /^HTTP 404:/.test(error.message);
 
   // ============= Rename Flow Hook =============
   const {
@@ -125,6 +132,10 @@ export function FlowIDEView({ flowId }: FlowIDEViewProps) {
       }
     }
   }, [currentFlow?.id]);
+
+  if (isFlowNotFound) {
+    return <FlowNotFoundView flowId={flowId} onRetry={() => refetch()} />;
+  }
 
   const isRunnable = () => {
     if (!currentFlow) return false;

--- a/apps/bubble-studio/src/components/FlowNotFoundView.tsx
+++ b/apps/bubble-studio/src/components/FlowNotFoundView.tsx
@@ -1,0 +1,59 @@
+import { useNavigate } from '@tanstack/react-router';
+
+export interface FlowNotFoundViewProps {
+  flowId: number;
+  onRetry?: () => void;
+}
+
+export function FlowNotFoundView({ flowId, onRetry }: FlowNotFoundViewProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="h-screen flex flex-col bg-[#1a1a1a] text-gray-100">
+      <div className="px-6 py-3 border-b border-[#30363d]">
+        <div className="flex items-center justify-between">
+          <div className="text-sm text-gray-300 font-medium">Bubble Studio</div>
+          <button
+            type="button"
+            onClick={() => navigate({ to: '/flows' })}
+            className="border border-gray-600/50 hover:border-gray-500/70 px-3 py-1 rounded-lg text-xs font-medium transition-all duration-200 text-gray-300 hover:text-gray-200"
+          >
+            Back to My Flows
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 flex items-center justify-center px-6">
+        <div className="max-w-lg w-full text-center">
+          <div className="text-6xl font-bold text-gray-200 tracking-tight">
+            404
+          </div>
+          <div className="mt-3 text-xl font-semibold text-gray-100">
+            Flow not found
+          </div>
+          <p className="mt-2 text-sm text-gray-400">
+            Flow <span className="text-gray-300">#{flowId}</span> doesn't exist,
+            was deleted, or you don't have access.
+          </p>
+
+          <div className="mt-6 flex items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={() => navigate({ to: '/flows' })}
+              className="bg-pink-600/20 hover:bg-pink-600/30 border border-pink-600/50 text-pink-300 hover:text-pink-200 hover:border-pink-500/70 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200"
+            >
+              Go to My Flows
+            </button>
+            <button
+              type="button"
+              onClick={() => onRetry?.()}
+              className="border border-gray-600/50 hover:border-gray-500/70 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 text-gray-300 hover:text-gray-200"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/bubble-studio/src/lib/api.ts
+++ b/apps/bubble-studio/src/lib/api.ts
@@ -7,6 +7,18 @@ export interface ApiError {
   data: unknown;
 }
 
+export class ApiHttpError extends Error implements ApiError {
+  status: number;
+  data: unknown;
+
+  constructor(status: number, data: unknown) {
+    super(`HTTP ${status}: ${JSON.stringify(data)}`);
+    this.name = 'ApiHttpError';
+    this.status = status;
+    this.data = data;
+  }
+}
+
 class ApiClient {
   private baseURL: string;
 
@@ -123,9 +135,7 @@ class ApiClient {
             toast.error('Request failed', { autoClose: 5000 });
           }
         }
-        throw new Error(
-          `HTTP ${response.status}: ${JSON.stringify(errorData)}`
-        );
+        throw new ApiHttpError(response.status, errorData);
       }
 
       // Handle successful responses
@@ -199,7 +209,7 @@ class ApiClient {
           toast.error('Request failed', { autoClose: 5000 });
         }
       }
-      throw new Error(`HTTP ${response.status}: ${JSON.stringify(errorData)}`);
+      throw new ApiHttpError(response.status, errorData);
     }
 
     return response;


### PR DESCRIPTION
## Summary

Adds a dedicated 404 “Flow not found” screen when navigating to a non-existent flow (e.g. `/flow/929292`) so we don’t render the flow visualizer or show “Pearl is generating…”. This improves UX and makes the missing-flow state explicit.

## Related Issues

Fixes [#194](https://github.com/bubblelabai/BubbleLab/issues/194)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added appropriate tests for my changes
- [x] I have run `pnpm check` and all tests pass
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

Before
<img width="1806" height="1256" alt="Screenshot 2025-12-13 at 9 13 09 AM" src="https://github.com/user-attachments/assets/1863047e-ad5d-4927-a1ea-76947eefed40" />

After
<img width="1810" height="1259" alt="Screenshot 2025-12-13 at 9 12 44 AM" src="https://github.com/user-attachments/assets/ef882235-8848-493d-a43b-b763b9c39134" />


## Additional Context

Implementation details:
- Introduces `ApiHttpError` to preserve HTTP status codes on API failures.
- `FlowIDEView` detects `404` and renders `FlowNotFoundView` instead of mounting the visualizer.