### PR TITLE
feat: add InsForge database integration

### DIFF
--- a/apps/bubble-studio/public/integrations/insforge.svg
+++ b/apps/bubble-studio/public/integrations/insforge.svg
@@ -1,0 +1,14 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M26.1184 101.6C23.2939 98.7833 23.2939 94.2166 26.1184 91.4L97.7167 20L200 20L77.26 142.4C74.4355 145.217 69.8562 145.217 67.0317 142.4L26.1184 101.6Z" fill="url(#paint0_linear_1_41)"/>
+<path d="M155.251 77.375L200 122V224L104.109 128.375L155.251 77.375Z" fill="url(#paint1_linear_1_41)"/>
+<defs>
+<linearGradient id="paint0_linear_1_41" x1="22.3955" y1="23.0754" x2="292.628" y2="116.332" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0.4"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1_41" x1="309.006" y1="103.841" x2="130.001" y2="103.841" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0.4"/>
+</linearGradient>
+</defs>
+</svg>

--- a/apps/bubble-studio/src/lib/integrations.ts
+++ b/apps/bubble-studio/src/lib/integrations.ts
@@ -30,6 +30,7 @@ export const SERVICE_LOGOS: Readonly<Record<string, string>> = Object.freeze({
   Telegram: '/integrations/telegram.svg',
   Airtable: '/integrations/airtable.png',
   Notion: '/integrations/notion.svg',
+  InsForge: '/integrations/insforge.svg',
 
   // AI models (also used as fallbacks for vendor names)
   GPT: '/integrations/gpt.svg',
@@ -71,6 +72,7 @@ export const INTEGRATIONS: IntegrationLogo[] = [
   { name: 'Telegram', file: SERVICE_LOGOS['Telegram'] },
   { name: 'Airtable', file: SERVICE_LOGOS['Airtable'] },
   { name: 'Notion', file: SERVICE_LOGOS['Notion'] },
+  { name: 'InsForge', file: SERVICE_LOGOS['InsForge'] },
 ];
 
 // Scraping services (Apify actors and general web scraping)
@@ -131,6 +133,8 @@ const NAME_ALIASES: Readonly<Record<string, string>> = Object.freeze({
   telegram: 'Telegram',
   airtable: 'Airtable',
   notion: 'Notion',
+  insforge: 'InsForge',
+  'insforge-db': 'InsForge',
   'research-agent': 'Research Agent',
   'research-agent-tool': 'Research Agent',
   research: 'Research Agent',

--- a/apps/bubble-studio/src/pages/CredentialsPage.tsx
+++ b/apps/bubble-studio/src/pages/CredentialsPage.tsx
@@ -234,6 +234,21 @@ const CREDENTIAL_TYPE_CONFIG: Record<CredentialType, CredentialConfig> = {
     namePlaceholder: 'My Airtable Token',
     credentialConfigurations: {},
   },
+  [CredentialType.INSFORGE_BASE_URL]: {
+    label: 'InsForge Base URL',
+    description:
+      'Base URL for your InsForge backend (e.g., https://your-app.region.insforge.app)',
+    placeholder: 'https://your-app.region.insforge.app',
+    namePlaceholder: 'My InsForge Backend URL',
+    credentialConfigurations: {},
+  },
+  [CredentialType.INSFORGE_API_KEY]: {
+    label: 'InsForge API Key',
+    description: 'API key for your InsForge backend',
+    placeholder: 'ik_...',
+    namePlaceholder: 'My InsForge API Key',
+    credentialConfigurations: {},
+  },
 } as const satisfies Record<CredentialType, CredentialConfig>;
 
 // Helper to extract error message from API error
@@ -282,6 +297,8 @@ const getServiceNameForCredentialType = (
     [CredentialType.ELEVENLABS_API_KEY]: 'ElevenLabs',
     [CredentialType.AIRTABLE_CRED]: 'Airtable',
     [CredentialType.NOTION_OAUTH_TOKEN]: 'Notion',
+    [CredentialType.INSFORGE_BASE_URL]: 'InsForge',
+    [CredentialType.INSFORGE_API_KEY]: 'InsForge',
   };
 
   return typeToServiceMap[credentialType] || credentialType;

--- a/packages/bubble-core/src/bubble-factory.ts
+++ b/packages/bubble-core/src/bubble-factory.ts
@@ -155,6 +155,7 @@ export class BubbleFactory {
       'airtable',
       'notion',
       'firecrawl',
+      'insforge-db',
     ];
   }
 
@@ -278,6 +279,9 @@ export class BubbleFactory {
     const { FirecrawlBubble } = await import(
       './bubbles/service-bubble/firecrawl.js'
     );
+    const { InsForgeDbBubble } = await import(
+      './bubbles/service-bubble/insforge-db.js'
+    );
 
     // Create the default factory instance
     this.register('hello-world', HelloWorldBubble as BubbleClassWithMetadata);
@@ -380,6 +384,7 @@ export class BubbleFactory {
     this.register('agi-inc', AGIIncBubble as BubbleClassWithMetadata);
     this.register('airtable', AirtableBubble as BubbleClassWithMetadata);
     this.register('firecrawl', FirecrawlBubble as BubbleClassWithMetadata);
+    this.register('insforge-db', InsForgeDbBubble as BubbleClassWithMetadata);
 
     // After all default bubbles are registered, auto-populate bubbleDependencies
     if (!BubbleFactory.dependenciesPopulated) {

--- a/packages/bubble-core/src/bubbles/service-bubble/insforge-db.ts
+++ b/packages/bubble-core/src/bubbles/service-bubble/insforge-db.ts
@@ -1,0 +1,348 @@
+import { z } from 'zod';
+import { ServiceBubble } from '../../types/service-bubble-class.js';
+import type { BubbleContext } from '../../types/bubble.js';
+import { CredentialType } from '@bubblelab/shared-schemas';
+
+// Define available SQL operations (same as PostgreSQL for consistency)
+export const SqlOperations = z.enum([
+  'SELECT',
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'CREATE',
+  'WITH',
+  'EXPLAIN',
+]);
+type SqlOperation = z.output<typeof SqlOperations>;
+
+// Define the parameters schema for the InsForge DB bubble
+const InsForgeDbParamsSchema = z.object({
+  query: z
+    .string()
+    .min(1, 'Query is required')
+    .describe('SQL query to execute against the InsForge database'),
+  allowedOperations: z
+    .array(SqlOperations)
+    .default(['SELECT', 'WITH'])
+    .describe(
+      'List of allowed SQL operations for security (defaults to read-only operations)'
+    ),
+  parameters: z
+    .array(z.unknown())
+    .optional()
+    .default([])
+    .describe(
+      'Parameters for parameterized queries (e.g., [value1, value2] for $1, $2)'
+    ),
+  timeout: z
+    .number()
+    .positive()
+    .default(30000)
+    .describe('Query timeout in milliseconds (default: 30 seconds)'),
+  maxRows: z
+    .number()
+    .positive()
+    .default(1000)
+    .describe('Maximum number of rows to return (default: 1000)'),
+  credentials: z
+    .record(z.nativeEnum(CredentialType), z.string())
+    .optional()
+    .describe(
+      'Object mapping credential types to values (injected at runtime)'
+    ),
+});
+
+type InsForgeDbParamsInput = z.input<typeof InsForgeDbParamsSchema>;
+type InsForgeDbParams = z.output<typeof InsForgeDbParamsSchema>;
+
+// Define the result schema
+const InsForgeDbResultSchema = z.object({
+  rows: z.array(z.record(z.unknown())).describe('Array of result rows'),
+  rowCount: z
+    .number()
+    .nullable()
+    .describe('Number of rows affected by the query'),
+  command: z.string().describe('SQL command that was executed'),
+  executionTime: z.number().describe('Query execution time in milliseconds'),
+  success: z.boolean().describe('Whether the query executed successfully'),
+  error: z.string().describe('Error message if query execution failed'),
+  cleanedJSONString: z
+    .string()
+    .describe('Clean JSON string representation of the row data'),
+});
+
+type InsForgeDbResult = z.output<typeof InsForgeDbResultSchema>;
+
+export type { InsForgeDbParamsInput };
+
+/**
+ * InsForge Database Bubble
+ *
+ * Execute SQL queries against an InsForge backend database.
+ * Works similarly to the PostgreSQL bubble but uses InsForge's REST API.
+ *
+ * @example
+ * ```typescript
+ * const result = await new InsForgeDbBubble({
+ *   query: 'SELECT * FROM users WHERE active = $1',
+ *   parameters: [true],
+ *   allowedOperations: ['SELECT'],
+ *   maxRows: 100,
+ * }).action();
+ *
+ * console.log(result.data.rows);
+ * ```
+ */
+export class InsForgeDbBubble extends ServiceBubble<
+  InsForgeDbParams,
+  InsForgeDbResult
+> {
+  static readonly type = 'service' as const;
+  static readonly service = 'insforge';
+  static readonly authType = 'apikey' as const;
+  static readonly bubbleName = 'insforge-db';
+  static readonly schema = InsForgeDbParamsSchema;
+  static readonly resultSchema = InsForgeDbResultSchema;
+  static readonly shortDescription =
+    'Execute SQL queries against InsForge database';
+  static readonly longDescription = `
+    Execute SQL queries against an InsForge backend database using the REST API.
+
+    Use cases:
+    - Data retrieval with SELECT queries
+    - Data manipulation with INSERT, UPDATE, DELETE (when explicitly allowed)
+    - Database reporting and analytics
+    - Data migration and synchronization tasks
+
+    Security Features:
+    - Operation whitelist (defaults to SELECT only)
+    - Parameterized queries to prevent SQL injection
+    - Connection timeout controls
+    - Result row limits
+  `;
+  static readonly alias = 'insforge';
+
+  constructor(
+    params: InsForgeDbParamsInput = {
+      query: 'SELECT 1',
+      allowedOperations: ['SELECT'],
+      parameters: [],
+      timeout: 30000,
+      maxRows: 1000,
+    },
+    context?: BubbleContext
+  ) {
+    super(params, context);
+
+    // Validate SQL operation
+    this.validateSqlOperation(this.params.query, this.params.allowedOperations);
+  }
+
+  public async testCredential(): Promise<boolean> {
+    const { credentials } = this.params;
+
+    if (!credentials || typeof credentials !== 'object') {
+      return false;
+    }
+
+    const baseUrl = credentials[CredentialType.INSFORGE_BASE_URL]?.replace(
+      /\/$/,
+      ''
+    );
+    const apiKey = credentials[CredentialType.INSFORGE_API_KEY];
+
+    // If only base URL provided, check if server is reachable
+    if (baseUrl && !apiKey) {
+      try {
+        const response = await fetch(`${baseUrl}/api/health`, {
+          method: 'GET',
+        });
+        return response.ok;
+      } catch {
+        return false;
+      }
+    }
+
+    // If only API key provided, can't validate without URL - return true
+    if (apiKey && !baseUrl) {
+      // Can't validate API key without base URL, assume valid
+      return true;
+    }
+
+    // If both provided, do full validation
+    if (baseUrl && apiKey) {
+      try {
+        const response = await fetch(
+          `${baseUrl}/api/database/advance/rawsql/unrestricted`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({
+              query: 'SELECT 1 as test',
+              params: [],
+            }),
+          }
+        );
+        return response.ok;
+      } catch {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  protected chooseCredential(): string | undefined {
+    // InsForge uses multiple credentials, handled in getCredentials()
+    return undefined;
+  }
+
+  private getCredentials(): { baseUrl: string; apiKey: string } {
+    const { credentials } = this.params;
+
+    if (!credentials || typeof credentials !== 'object') {
+      throw new Error('No InsForge credentials provided');
+    }
+
+    const baseUrl = credentials[CredentialType.INSFORGE_BASE_URL];
+    const apiKey = credentials[CredentialType.INSFORGE_API_KEY];
+
+    if (!baseUrl) {
+      throw new Error('InsForge base URL not provided');
+    }
+    if (!apiKey) {
+      throw new Error('InsForge API key not provided');
+    }
+
+    // Remove trailing slash from base URL
+    return {
+      baseUrl: baseUrl.replace(/\/$/, ''),
+      apiKey,
+    };
+  }
+
+  /**
+   * Validate that the SQL query operation is allowed
+   */
+  private validateSqlOperation(
+    query: string,
+    allowedOperations: SqlOperation[]
+  ): void {
+    const trimmedQuery = query.trim().toUpperCase();
+    const firstKeyword = trimmedQuery.split(/\s+/)[0];
+
+    const isAllowed = allowedOperations.some((op) =>
+      firstKeyword.startsWith(op)
+    );
+
+    if (!isAllowed) {
+      throw new Error(
+        `SQL operation '${firstKeyword}' is not allowed. Allowed operations: ${allowedOperations.join(', ')}`
+      );
+    }
+
+    // Safety checks for dangerous operations
+    if (firstKeyword === 'DELETE' && !trimmedQuery.includes('WHERE')) {
+      throw new Error('DELETE queries must include a WHERE clause for safety');
+    }
+
+    if (firstKeyword === 'UPDATE' && !trimmedQuery.includes('WHERE')) {
+      throw new Error('UPDATE queries must include a WHERE clause for safety');
+    }
+
+    // Block dangerous keywords
+    const dangerousKeywords = [
+      '\\bDROP\\b',
+      '\\bALTER\\b',
+      '\\bTRUNCATE\\b',
+      '\\bGRANT\\b',
+      '\\bREVOKE\\b',
+    ];
+
+    const containsDangerous = dangerousKeywords.some((keyword) =>
+      new RegExp(keyword, 'i').test(trimmedQuery)
+    );
+
+    if (containsDangerous) {
+      throw new Error(
+        `Query contains potentially dangerous operations. Only allowed: ${allowedOperations.join(', ')}`
+      );
+    }
+  }
+
+  protected async performAction(
+    context?: BubbleContext
+  ): Promise<InsForgeDbResult> {
+    void context;
+
+    const { query, parameters, maxRows } = this.params;
+    const { baseUrl, apiKey } = this.getCredentials();
+    const startTime = Date.now();
+
+    try {
+      // Call InsForge raw SQL endpoint
+      const response = await fetch(
+        `${baseUrl}/api/database/advance/rawsql/unrestricted`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            query,
+            params: parameters,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(
+          `InsForge query failed: ${response.status} - ${errorBody}`
+        );
+      }
+
+      const data = (await response.json()) as
+        | Record<string, unknown>[]
+        | { rows?: Record<string, unknown>[] };
+      const executionTime = Date.now() - startTime;
+
+      // Handle response - InsForge returns array of rows or object with rows property
+      const rows: Record<string, unknown>[] = Array.isArray(data)
+        ? data
+        : (data as { rows?: Record<string, unknown>[] }).rows || [];
+      const truncatedRows = rows.slice(0, maxRows);
+
+      // Extract command from query
+      const command = query.trim().split(/\s+/)[0].toUpperCase();
+
+      return {
+        rows: truncatedRows,
+        rowCount: rows.length,
+        command,
+        executionTime,
+        success: true,
+        error: '',
+        cleanedJSONString: JSON.stringify(truncatedRows, null, 2),
+      };
+    } catch (error) {
+      const executionTime = Date.now() - startTime;
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error occurred';
+
+      return {
+        rows: [],
+        rowCount: null,
+        command: query.trim().split(/\s+/)[0].toUpperCase(),
+        executionTime,
+        success: false,
+        error: errorMessage,
+        cleanedJSONString: '[]',
+      };
+    }
+  }
+}

--- a/packages/bubble-core/src/index.ts
+++ b/packages/bubble-core/src/index.ts
@@ -66,6 +66,8 @@ export type { AirtableParamsInput } from './bubbles/service-bubble/airtable.js';
 export { NotionBubble } from './bubbles/service-bubble/notion/notion.js';
 export type { FirecrawlParamsInput } from './bubbles/service-bubble/firecrawl.js';
 export { FirecrawlBubble } from './bubbles/service-bubble/firecrawl.js';
+export { InsForgeDbBubble } from './bubbles/service-bubble/insforge-db.js';
+export type { InsForgeDbParamsInput } from './bubbles/service-bubble/insforge-db.js';
 
 // Export workflow bubbles
 export { DatabaseAnalyzerWorkflowBubble } from './bubbles/workflow-bubble/database-analyzer.workflow.js';

--- a/packages/bubble-shared-schemas/src/bubble-definition-schema.ts
+++ b/packages/bubble-shared-schemas/src/bubble-definition-schema.ts
@@ -44,6 +44,8 @@ export const CREDENTIAL_CONFIGURATION_MAP: Record<
   [CredentialType.GITHUB_TOKEN]: {},
   [CredentialType.AIRTABLE_CRED]: {},
   [CredentialType.NOTION_OAUTH_TOKEN]: {},
+  [CredentialType.INSFORGE_BASE_URL]: {},
+  [CredentialType.INSFORGE_API_KEY]: {},
 };
 
 // Fixed list of bubble names that need context injection

--- a/packages/bubble-shared-schemas/src/credential-schema.ts
+++ b/packages/bubble-shared-schemas/src/credential-schema.ts
@@ -29,6 +29,8 @@ export const CREDENTIAL_ENV_MAP: Record<CredentialType, string> = {
   [CredentialType.AGI_API_KEY]: 'AGI_API_KEY',
   [CredentialType.AIRTABLE_CRED]: 'AIRTABLE_API_KEY',
   [CredentialType.NOTION_OAUTH_TOKEN]: '',
+  [CredentialType.INSFORGE_BASE_URL]: 'INSFORGE_BASE_URL',
+  [CredentialType.INSFORGE_API_KEY]: 'INSFORGE_API_KEY',
 };
 
 /** Used by bubblelab studio */
@@ -363,6 +365,10 @@ export const BUBBLE_CREDENTIAL_OPTIONS: Record<BubbleName, CredentialType[]> = {
   airtable: [CredentialType.AIRTABLE_CRED],
   notion: [CredentialType.NOTION_OAUTH_TOKEN],
   firecrawl: [CredentialType.FIRECRAWL_API_KEY],
+  'insforge-db': [
+    CredentialType.INSFORGE_BASE_URL,
+    CredentialType.INSFORGE_API_KEY,
+  ],
 };
 
 // POST /credentials - Create credential schema

--- a/packages/bubble-shared-schemas/src/types.ts
+++ b/packages/bubble-shared-schemas/src/types.ts
@@ -41,6 +41,10 @@ export enum CredentialType {
 
   // Database/Storage Credentials
   AIRTABLE_CRED = 'AIRTABLE_CRED',
+
+  // InsForge Credentials
+  INSFORGE_BASE_URL = 'INSFORGE_BASE_URL',
+  INSFORGE_API_KEY = 'INSFORGE_API_KEY',
 }
 
 // Define all bubble names as a union type for type safety
@@ -89,4 +93,5 @@ export type BubbleName =
   | 'telegram'
   | 'airtable'
   | 'notion'
-  | 'firecrawl';
+  | 'firecrawl'
+  | 'insforge-db';


### PR DESCRIPTION
Changes: 
- Add InsForge DB bubble for executing SQL queries via InsForge REST API
- Add INSFORGE_BASE_URL and INSFORGE_API_KEY credential types
- Support SELECT, INSERT, UPDATE, DELETE, CREATE, WITH, EXPLAIN operations
- Add InsForge logo and integration config in Bubble Studio
- Include SQL injection protection and dangerous operation blocking

Discussed with @zhubzy  on discord. Let me know if you need an issue for this

## Summary

<!-- Provide a short summary of your changes and the motivation behind them. -->

Adding insforge Integration to bubble! 
InsForge is the Backend Platform for AI Coding Agents.  Bubble Labs is a great data injection source as it provides scraper + cron jobs!  This integration allows GUI visualization with database, and convenient subsequent development.

## Related Issues

<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [ x] My code follows the code style of this project
- [ x] I have added appropriate tests for my changes
- [ x] I have run `pnpm check` and all tests pass
- [ x] I have tested my changes locally
- [ x] I have linked relevant issues
- [ x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

<!-- Add before/after screenshots or GIFs here -->

I'm creating a full stack webapp with bubble lab as data ingestion layer, and insforge as the backend /frontend layer.

<img width="1405" height="816" alt="Screenshot 2025-12-14 at 20 25 50" src="https://github.com/user-attachments/assets/09f402be-f836-4678-9cb8-7445a4fa698d" />

We see insforge has data loaded
<img width="1303" height="664" alt="Screenshot 2025-12-14 at 20 28 48" src="https://github.com/user-attachments/assets/551c452b-f31f-4fd3-a9d5-3a14122d9b95" />


## Additional Context

<!-- Add any other context or information about the PR here -->
