### PR TITLE
Threads context

### DIFF
--- a/packages/bubble-core/package.json
+++ b/packages/bubble-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bubblelab/bubble-core",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/bubble-core/src/bubble-flow/bubble-flow-class.ts
+++ b/packages/bubble-core/src/bubble-flow/bubble-flow-class.ts
@@ -15,6 +15,7 @@ export abstract class BubbleFlow<
     executionId?: number;
     studioBaseUrl?: string;
   };
+  __triggerConversationHistory__?: Array<{ role: string; content: string }>;
 
   /**
    * Cron schedule expression for schedule/cron event types.

--- a/packages/bubble-core/src/bubbles/service-bubble/ai-agent.ts
+++ b/packages/bubble-core/src/bubbles/service-bubble/ai-agent.ts
@@ -587,6 +587,19 @@ export class AIAgentBubble extends ServiceBubble<
       this.context,
       this.resolveCapabilityCredentials.bind(this)
     );
+
+    // Auto-inject trigger conversation history if no explicit conversationHistory was provided
+    // This enables Slack thread context to automatically flow into AI agents
+    if (
+      !this.params.conversationHistory?.length &&
+      this.context?.triggerConversationHistory
+    ) {
+      this.params.conversationHistory = this.context
+        .triggerConversationHistory as Array<{
+        role: 'user' | 'assistant';
+        content: string;
+      }>;
+    }
   }
 
   protected async performAction(

--- a/packages/bubble-runtime/package.json
+++ b/packages/bubble-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bubblelab/bubble-runtime",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/bubble-runtime/src/runtime/BubbleRunner.ts
+++ b/packages/bubble-runtime/src/runtime/BubbleRunner.ts
@@ -488,6 +488,33 @@ export class BubbleRunner {
         (flowInstance as any).__executionMeta__ = this.options.executionMeta;
       }
 
+      // Extract thread_histories from trigger payload and convert to conversation history
+      // format for auto-injection into AI agents (avoids Pearl needing to generate mapping code)
+      if (
+        webhookPayload &&
+        Array.isArray((webhookPayload as any).thread_histories)
+      ) {
+        const threadHistories = (webhookPayload as any)
+          .thread_histories as Array<{
+          user_id: string;
+          name: string;
+          message: string;
+        }>;
+        if (threadHistories.length > 0) {
+          // Convert to {role, content} format — all thread messages are "user" role
+          // The last entry is the current message that triggered the flow (already in `message` param),
+          // so we only include history up to but NOT including it to avoid duplication
+          const historyWithoutCurrent = threadHistories.slice(0, -1);
+          if (historyWithoutCurrent.length > 0) {
+            (flowInstance as any).__triggerConversationHistory__ =
+              historyWithoutCurrent.map((h) => ({
+                role: 'user' as const,
+                content: `[${h.name}]: ${h.message}`,
+              }));
+          }
+        }
+      }
+
       // Ensure the logger is set on the flow instance
       if (this.logger) {
         if (typeof flowInstance.setLogger === 'function') {

--- a/packages/bubble-runtime/src/utils/parameter-formatter.ts
+++ b/packages/bubble-runtime/src/utils/parameter-formatter.ts
@@ -87,7 +87,7 @@ export function buildParametersObject(
       const currentIdPart = `, currentUniqueId: ${currentUniqueIdExpr}`;
       const invocationKeyPart =
         ', invocationCallSiteKey: __bubbleFlowSelf?.__getInvocationCallSiteKey?.()';
-      return `${paramValue}, {logger: __bubbleFlowSelf.logger, variableId: ${variableIdExpr}${depGraphPart}${currentIdPart}${invocationKeyPart}, executionMeta: __bubbleFlowSelf?.__executionMeta__}`;
+      return `${paramValue}, {logger: __bubbleFlowSelf.logger, variableId: ${variableIdExpr}${depGraphPart}${currentIdPart}${invocationKeyPart}, executionMeta: __bubbleFlowSelf?.__executionMeta__, triggerConversationHistory: __bubbleFlowSelf?.__triggerConversationHistory__}`;
     }
 
     return paramValue;
@@ -142,7 +142,7 @@ export function buildParametersObject(
         const currentIdPart = `, currentUniqueId: ${currentUniqueIdExpr}`;
         const invocationKeyPart =
           ', invocationCallSiteKey: __bubbleFlowSelf?.__getInvocationCallSiteKey?.()';
-        return `{...${paramsValue}, credentials: ${credentialsValue}}, {logger: __bubbleFlowSelf.logger, variableId: ${variableIdExpr}${depGraphPart}${currentIdPart}${invocationKeyPart}, executionMeta: __bubbleFlowSelf?.__executionMeta__}`;
+        return `{...${paramsValue}, credentials: ${credentialsValue}}, {logger: __bubbleFlowSelf.logger, variableId: ${variableIdExpr}${depGraphPart}${currentIdPart}${invocationKeyPart}, executionMeta: __bubbleFlowSelf?.__executionMeta__, triggerConversationHistory: __bubbleFlowSelf?.__triggerConversationHistory__}`;
       }
 
       return `{...${paramsValue}, credentials: ${credentialsValue}}`;
@@ -185,7 +185,7 @@ export function buildParametersObject(
     const currentIdPart = `, currentUniqueId: ${currentUniqueIdExpr}`;
     const invocationKeyPart =
       ', invocationCallSiteKey: __bubbleFlowSelf?.__getInvocationCallSiteKey?.()';
-    return `${paramsString}, {logger: __bubbleFlowSelf.logger, variableId: ${variableIdExpr}${depGraphPart}${currentIdPart}${invocationKeyPart}, executionMeta: __bubbleFlowSelf?.__executionMeta__}`;
+    return `${paramsString}, {logger: __bubbleFlowSelf.logger, variableId: ${variableIdExpr}${depGraphPart}${currentIdPart}${invocationKeyPart}, executionMeta: __bubbleFlowSelf?.__executionMeta__, triggerConversationHistory: __bubbleFlowSelf?.__triggerConversationHistory__}`;
   }
 
   return paramsString;

--- a/packages/bubble-scope-manager/package.json
+++ b/packages/bubble-scope-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bubblelab/ts-scope-manager",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "private": false,
   "license": "MIT",
   "type": "commonjs",

--- a/packages/bubble-shared-schemas/package.json
+++ b/packages/bubble-shared-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bubblelab/shared-schemas",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/create-bubblelab-app/package.json
+++ b/packages/create-bubblelab-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bubblelab-app",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "license": "Apache-2.0",
   "description": "Create BubbleLab AI agent applications with one command",


### PR DESCRIPTION
## Summary

<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues

<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] New Bubble Integration
- [ ] Other (please describe):

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have added appropriate tests for my changes
- [ ] I have run `pnpm check` and all tests pass
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues

## Screenshots (Required)

<!-- Add screenshots showing the full result in BubbleLab. This is mandatory for all PRs. -->

## For New Bubble Integrations

> 📋 **Integration Flow Tests:** When creating a new bubble, you must write an integration flow test that exercises all operations end-to-end in realistic scenarios—including edge cases. This flow should be runnable in bubble studio and return structured results tracking each operation's success/failure with details. See `packages/bubble-core/src/bubbles/service-bubble/google-sheets/google-sheets.integration.flow.ts` for a complete reference implementation.
>
> ⚠️ If your integration requires API credits for testing, please reach out to the team for test credentials.

- [ ] Integration flow test (`.integration.flow.ts`) covers all operations
- [ ] Screenshots showing full test results in Bubble Studio attached above

## Additional Context

<!-- Add any other context or information about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI agents now automatically capture and utilize conversation history from Slack threads, enabling improved multi-turn context awareness without requiring explicit input.

* **Chores**
  * Updated package versions across the platform (0.1.138 → 0.1.139).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->