### PR TITLE
fix(salesforce): use full scope and remove prompt parameter

### DIFF
--- a/packages/bubble-core/package.json
+++ b/packages/bubble-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bubblelab/bubble-core",
-  "version": "0.1.285",
+  "version": "0.1.286",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/bubble-runtime/package.json
+++ b/packages/bubble-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bubblelab/bubble-runtime",
-  "version": "0.1.285",
+  "version": "0.1.286",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/bubble-scope-manager/package.json
+++ b/packages/bubble-scope-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bubblelab/ts-scope-manager",
-  "version": "0.1.285",
+  "version": "0.1.286",
   "private": false,
   "license": "MIT",
   "type": "commonjs",

--- a/packages/bubble-shared-schemas/package.json
+++ b/packages/bubble-shared-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bubblelab/shared-schemas",
-  "version": "0.1.285",
+  "version": "0.1.286",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/bubble-shared-schemas/src/credential-schema.ts
+++ b/packages/bubble-shared-schemas/src/credential-schema.ts
@@ -2046,14 +2046,14 @@ export const OAUTH_PROVIDERS: Record<OAuthProvider, OAuthProviderConfig> = {
     credentialTypes: {
       [CredentialType.SALESFORCE_CRED]: {
         displayName: 'Salesforce',
-        defaultScopes: ['api', 'refresh_token', 'openid'],
+        defaultScopes: ['full', 'refresh_token', 'openid'],
         description:
           'Access Salesforce for managing accounts, contacts, opportunities, and records via REST API',
         scopeDescriptions: [
           {
-            scope: 'api',
+            scope: 'full',
             description:
-              'Access Salesforce REST API for reading and writing data (accounts, contacts, opportunities, etc.)',
+              'Full access to all permitted Salesforce resources and features',
             defaultEnabled: true,
           },
           {
@@ -2069,9 +2069,9 @@ export const OAUTH_PROVIDERS: Record<OAuthProvider, OAuthProviderConfig> = {
             defaultEnabled: true,
           },
           {
-            scope: 'full',
+            scope: 'api',
             description:
-              'Full access to all permitted Salesforce resources and features',
+              'Access Salesforce REST API for reading and writing data (accounts, contacts, opportunities, etc.)',
             defaultEnabled: false,
           },
           {
@@ -2082,9 +2082,7 @@ export const OAUTH_PROVIDERS: Record<OAuthProvider, OAuthProviderConfig> = {
         ],
       },
     },
-    authorizationParams: {
-      prompt: 'login', // Force login screen so user can choose which Salesforce org to connect
-    },
+    authorizationParams: {},
   },
   asana: {
     name: 'asana',

--- a/packages/create-bubblelab-app/package.json
+++ b/packages/create-bubblelab-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bubblelab-app",
-  "version": "0.1.285",
+  "version": "0.1.286",
   "type": "module",
   "license": "Apache-2.0",
   "description": "Create BubbleLab AI agent applications with one command",

--- a/packages/create-bubblelab-app/templates/basic/package.json
+++ b/packages/create-bubblelab-app/templates/basic/package.json
@@ -11,9 +11,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@bubblelab/bubble-core": "^0.1.285",
-    "@bubblelab/bubble-runtime": "^0.1.285",
-    "@bubblelab/shared-schemas": "^0.1.285",
+    "@bubblelab/bubble-core": "^0.1.286",
+    "@bubblelab/bubble-runtime": "^0.1.286",
+    "@bubblelab/shared-schemas": "^0.1.286",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {

--- a/packages/create-bubblelab-app/templates/reddit-scraper/package.json
+++ b/packages/create-bubblelab-app/templates/reddit-scraper/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@bubblelab/bubble-core": "^0.1.285",
-    "@bubblelab/bubble-runtime": "^0.1.285",
+    "@bubblelab/bubble-core": "^0.1.286",
+    "@bubblelab/bubble-runtime": "^0.1.286",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Changed default Salesforce OAuth scopes from `api` to `full` (fixes OAUTH_APPROVAL_ERROR_GENERIC)
- Removed `prompt: 'login'` authorization param (causes generic OAuth errors with External Client Apps)

## Test plan
- [x] Tested OAuth flow locally — consent screen shows and token exchange succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Salesforce OAuth authentication by removing forced login behavior and updating default permission scopes.

* **Chores**
  * Updated package versions across core modules and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->